### PR TITLE
Add PostgreSQL database schema migrations

### DIFF
--- a/backend/migrations/001_create_users.sql
+++ b/backend/migrations/001_create_users.sql
@@ -1,0 +1,29 @@
+-- Migration: 001_create_users
+-- Tabelle: users
+
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email TEXT NOT NULL UNIQUE,
+    username TEXT NOT NULL UNIQUE,
+    display_name TEXT NOT NULL,
+    profile_image_url TEXT,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ,
+    last_seen_at TIMESTAMPTZ,
+
+    bio TEXT,
+    preferences JSONB,
+    favorite_categories TEXT[] NOT NULL DEFAULT '{}',
+
+    is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    is_moderator BOOLEAN NOT NULL DEFAULT FALSE,
+    is_private BOOLEAN NOT NULL DEFAULT FALSE,
+
+    fcm_token TEXT,
+
+    stats JSONB NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX idx_users_created_at ON users(created_at);
+CREATE INDEX idx_users_last_seen_at ON users(last_seen_at);

--- a/backend/migrations/002_create_locations.sql
+++ b/backend/migrations/002_create_locations.sql
@@ -1,0 +1,49 @@
+-- Migration: 002_create_locations
+-- Tabelle: locations
+
+CREATE TABLE locations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    address TEXT NOT NULL,
+    latitude DOUBLE PRECISION NOT NULL,
+    longitude DOUBLE PRECISION NOT NULL,
+    coordinates POINT NOT NULL,
+    geohash TEXT NOT NULL,
+    category TEXT NOT NULL,
+
+    average_rating DOUBLE PRECISION NOT NULL DEFAULT 0,
+    total_ratings INT NOT NULL DEFAULT 0,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ,
+    created_by UUID NOT NULL REFERENCES users(id),
+
+    image_urls TEXT[] NOT NULL DEFAULT '{}',
+    thumbnail_url TEXT,
+    tags TEXT[] NOT NULL DEFAULT '{}',
+
+    price_range TEXT,
+    opening_hours JSONB,
+    parking_info JSONB,
+    accessibility JSONB,
+
+    noise_level TEXT,
+    wifi_available BOOLEAN,
+    is_dog_friendly BOOLEAN,
+    is_family_friendly BOOLEAN,
+
+    phone_number TEXT,
+    website TEXT,
+    instagram_handle TEXT,
+
+    is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    report_count INT NOT NULL DEFAULT 0,
+    trending_score DOUBLE PRECISION
+);
+
+CREATE INDEX idx_locations_category ON locations(category);
+CREATE INDEX idx_locations_created_by ON locations(created_by);
+CREATE INDEX idx_locations_geohash ON locations(geohash text_pattern_ops);
+CREATE INDEX idx_locations_coordinates ON locations USING gist(coordinates);
+CREATE INDEX idx_locations_average_rating ON locations(average_rating DESC);
+CREATE INDEX idx_locations_created_at ON locations(created_at);

--- a/backend/migrations/003_create_ratings.sql
+++ b/backend/migrations/003_create_ratings.sql
@@ -1,0 +1,42 @@
+-- Migration: 003_create_ratings
+-- Tabelle: ratings
+
+CREATE TABLE ratings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    location_id UUID NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+    location_name TEXT NOT NULL,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    username TEXT NOT NULL,
+    user_profile_image_url TEXT,
+
+    rating SMALLINT NOT NULL CHECK (rating BETWEEN 1 AND 5),
+    comment TEXT,
+    image_urls TEXT[] NOT NULL DEFAULT '{}',
+    thumbnail_urls TEXT[] NOT NULL DEFAULT '{}',
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ,
+
+    trip_id UUID,
+    is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    verified_at TIMESTAMPTZ,
+
+    report_count INT NOT NULL DEFAULT 0,
+    is_hidden BOOLEAN NOT NULL DEFAULT FALSE,
+
+    reaction_count INT NOT NULL DEFAULT 0,
+    comment_count INT NOT NULL DEFAULT 0,
+    helpful_count INT NOT NULL DEFAULT 0,
+
+    visit_date TIMESTAMPTZ,
+    price_spent DOUBLE PRECISION,
+    would_recommend BOOLEAN
+);
+
+CREATE INDEX idx_ratings_location_id ON ratings(location_id);
+CREATE INDEX idx_ratings_user_id ON ratings(user_id);
+CREATE INDEX idx_ratings_created_at ON ratings(created_at DESC);
+CREATE INDEX idx_ratings_trip_id ON ratings(trip_id) WHERE trip_id IS NOT NULL;
+
+-- Ein User kann eine Location nur einmal bewerten
+CREATE UNIQUE INDEX idx_ratings_unique_user_location ON ratings(user_id, location_id);

--- a/backend/migrations/004_create_friendships.sql
+++ b/backend/migrations/004_create_friendships.sql
@@ -1,0 +1,25 @@
+-- Migration: 004_create_friendships
+-- Tabelle: friendships
+
+CREATE TABLE friendships (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    requester_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    receiver_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'declined', 'blocked')),
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    accepted_at TIMESTAMPTZ,
+
+    requester_username TEXT NOT NULL,
+    receiver_username TEXT NOT NULL,
+
+    CONSTRAINT no_self_friendship CHECK (requester_id != receiver_id)
+);
+
+CREATE UNIQUE INDEX idx_friendships_pair ON friendships(
+    LEAST(requester_id, receiver_id),
+    GREATEST(requester_id, receiver_id)
+);
+CREATE INDEX idx_friendships_requester ON friendships(requester_id);
+CREATE INDEX idx_friendships_receiver ON friendships(receiver_id);
+CREATE INDEX idx_friendships_status ON friendships(status);

--- a/backend/migrations/005_create_trips.sql
+++ b/backend/migrations/005_create_trips.sql
@@ -1,0 +1,37 @@
+-- Migration: 005_create_trips
+-- Tabellen: trips + trip_participants
+
+CREATE TABLE trips (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    username TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+
+    location_count INT NOT NULL DEFAULT 0,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ,
+    start_date TIMESTAMPTZ,
+    end_date TIMESTAMPTZ,
+
+    cover_image_url TEXT,
+    is_collaborative BOOLEAN NOT NULL DEFAULT FALSE,
+    is_public BOOLEAN NOT NULL DEFAULT FALSE,
+    view_count INT NOT NULL DEFAULT 0,
+    reminder_date TIMESTAMPTZ
+);
+
+CREATE TABLE trip_participants (
+    trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (trip_id, user_id)
+);
+
+-- ratings.trip_id FK nachtragen
+ALTER TABLE ratings ADD CONSTRAINT fk_ratings_trip FOREIGN KEY (trip_id) REFERENCES trips(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_trips_user_id ON trips(user_id);
+CREATE INDEX idx_trips_created_at ON trips(created_at DESC);
+CREATE INDEX idx_trips_is_public ON trips(is_public) WHERE is_public = TRUE;


### PR DESCRIPTION
## Summary
  - 5 SQL-Migrationsdateien für das komplette Datenbankschema (Issue #3)
  - Tabellen: users, locations, ratings, friendships, trips, trip_participants
  - Foreign Keys, Indizes und CHECK Constraints eingerichtet
  - Schema bereits auf dem Server (217.154.243.150) ausgeführt und verifiziert

  closes #3