### PR TITLE
Add session persistence check in LoginView

### DIFF
--- a/Sidequest3/Sidequest3App.swift
+++ b/Sidequest3/Sidequest3App.swift
@@ -19,6 +19,9 @@ struct Sidequest3App: App {
                     .environmentObject(container)
             } else {
                 LoginView(authViewModel: authViewModel)
+                    .task {
+                        await authViewModel.checkExistingSession()
+                    }
             }
         }
     }


### PR DESCRIPTION
## Summary
  - checkExistingSession() wird beim App-Start aufgerufen
  - Gespeicherte Apple User ID aus UserDefaults wird gelesen und User automatisch eingeloggt

  Fixes #25