### PR TITLE
Fix map position reset on move

### DIFF
--- a/Sidequest3/Karte.swift
+++ b/Sidequest3/Karte.swift
@@ -13,6 +13,7 @@ import Combine
 class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
 
     private let manager = CLLocationManager()
+    private var hasSetInitialPosition = false
 
     @Published var position: MapCameraPosition = .region(MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 52.5200, longitude: 13.4050),
@@ -28,7 +29,9 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard let location = locations.first else { return }
+        guard let location = locations.first, !hasSetInitialPosition else { return }
+        hasSetInitialPosition = true
+        manager.stopUpdatingLocation()
 
         DispatchQueue.main.async {
             self.position = .region(MKCoordinateRegion(


### PR DESCRIPTION
## Summary
  - Map-Position wird nur einmal beim Start auf den aktuellen Standort gesetzt
  - Location-Updates werden danach gestoppt
  - User kann sich frei auf der Karte bewegen

  Fixes #27