### PR TITLE
fix: use native Map selection with .tag() instead of onTapGesture

### DIFF
--- a/Sidequest3/Karte.swift
+++ b/Sidequest3/Karte.swift
@@ -68,10 +68,7 @@ struct Karte: View {
                             
                     )) {
                         LocationPin(imageUrl: location.imageUrls.first)
-                            .onTapGesture {
-                                selectedLocationId = location.id
-                                showDetail = true
-                            }
+                            .tag(location.id)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Fixes a bug where location pins on the map could not always be tapped/selected (#32)
- Root cause: `Map(selection:)` binding and `.onTapGesture` on pins conflicted – MapKit consumed the tap before the gesture handler fired
- Fix: Replaced `.onTapGesture` with `.tag(location.id)` so MapKit can properly identify annotations via its native selection mechanism

Fixes #32