### PR TITLE
feat: profile share card with QR code friend link

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.sidequest.app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>sidequest</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/Sidequest3/Profile.swift
+++ b/Sidequest3/Profile.swift
@@ -14,6 +14,7 @@ struct Profile: View {
     @State private var showLogoutAlert = false
     @State private var showEditProfile = false
     @State private var showFriends = false
+    @State private var showShareCard = false
     @State private var selectedLocation: Location?
 
     var body: some View {
@@ -54,6 +55,11 @@ struct Profile: View {
             }
             .sheet(isPresented: $showFriends) {
                 FriendsView(currentUser: authViewModel.currentUser)
+            }
+            .sheet(isPresented: $showShareCard) {
+                if let user = authViewModel.currentUser {
+                    ProfileShareCardView(user: user)
+                }
             }
             .sheet(item: $selectedLocation) { location in
                 NavigationStack {
@@ -186,7 +192,9 @@ struct Profile: View {
             }
             .buttonStyle(.plain)
 
-            ShareLink(item: "Schau dir mein Profil auf Sidequest an! @\(authViewModel.currentUser?.username ?? "")") {
+            Button {
+                showShareCard = true
+            } label: {
                 Image(systemName: "square.and.arrow.up")
                     .font(.subheadline.weight(.semibold))
                     .padding(.vertical, 8)
@@ -194,6 +202,7 @@ struct Profile: View {
                     .background(Color(.systemGray5))
                     .clipShape(RoundedRectangle(cornerRadius: 8))
             }
+            .buttonStyle(.plain)
         }
     }
 

--- a/Sidequest3/Sidequest3App.swift
+++ b/Sidequest3/Sidequest3App.swift
@@ -11,12 +11,36 @@ import SwiftUI
 struct Sidequest3App: App {
     @StateObject private var container = DependencyContainer()
     @State private var authViewModel = AuthViewModel()
+    @State private var deepLinkFriendUsername: String?
 
     var body: some Scene {
         WindowGroup {
             if authViewModel.isAuthenticated {
                 Home(authViewModel: authViewModel)
                     .environmentObject(container)
+                    .onOpenURL { url in
+                        handleDeepLink(url)
+                    }
+                    .alert("Freund hinzufuegen?", isPresented: .init(
+                        get: { deepLinkFriendUsername != nil },
+                        set: { if !$0 { deepLinkFriendUsername = nil } }
+                    )) {
+                        Button("Anfrage senden") {
+                            if let username = deepLinkFriendUsername,
+                               let userId = authViewModel.currentUser?.id {
+                                Task {
+                                    let service = FriendshipService()
+                                    _ = try? await service.sendRequest(requesterId: userId, receiverUsername: username)
+                                }
+                                deepLinkFriendUsername = nil
+                            }
+                        }
+                        Button("Abbrechen", role: .cancel) {
+                            deepLinkFriendUsername = nil
+                        }
+                    } message: {
+                        Text("Moechtest du @\(deepLinkFriendUsername ?? "") eine Freundschaftsanfrage senden?")
+                    }
             } else {
                 LoginView(authViewModel: authViewModel)
                     .task {
@@ -24,5 +48,15 @@ struct Sidequest3App: App {
                     }
             }
         }
+    }
+
+    private func handleDeepLink(_ url: URL) {
+        // sidequest://add-friend/{username}
+        guard url.scheme == "sidequest",
+              url.host == "add-friend",
+              let username = url.pathComponents.last,
+              username != "/",
+              username != authViewModel.currentUser?.username else { return }
+        deepLinkFriendUsername = username
     }
 }

--- a/Sidequest3/Views/ProfileShareCardView.swift
+++ b/Sidequest3/Views/ProfileShareCardView.swift
@@ -1,0 +1,248 @@
+//
+//  ProfileShareCardView.swift
+//  Sidequest
+//
+
+import SwiftUI
+import CoreImage.CIFilterBuiltins
+
+// MARK: - Share Card Layout (rendered to image)
+
+struct ProfileShareCardContent: View {
+    let user: User
+    let qrImage: UIImage?
+    let profileImage: UIImage?
+
+    private let cardWidth: CGFloat = 360
+    private let cardHeight: CGFloat = 480
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Top: Indigo header area with profile
+            ZStack {
+                // Indigo gradient background
+                LinearGradient(
+                    colors: [
+                        Color(.systemIndigo),
+                        Color(.systemIndigo).opacity(0.85)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+
+                VStack(spacing: 12) {
+                    // Profile image
+                    Group {
+                        if let profileImage {
+                            Image(uiImage: profileImage)
+                                .resizable()
+                                .scaledToFill()
+                        } else {
+                            Color.white.opacity(0.2)
+                                .overlay(
+                                    Text(String(user.displayName.prefix(1)).uppercased())
+                                        .font(.system(size: 32, weight: .bold, design: .rounded))
+                                        .foregroundStyle(.white)
+                                )
+                        }
+                    }
+                    .frame(width: 76, height: 76)
+                    .clipShape(Circle())
+                    .overlay(Circle().stroke(.white.opacity(0.3), lineWidth: 2))
+
+                    // Name + username
+                    VStack(spacing: 4) {
+                        Text(user.displayName)
+                            .font(.title3.bold())
+                            .foregroundStyle(.white)
+
+                        Text("@\(user.username)")
+                            .font(.subheadline)
+                            .foregroundStyle(.white.opacity(0.7))
+                    }
+                }
+                .padding(.vertical, 36)
+            }
+            .frame(height: 210)
+
+            // Bottom: White area with QR code
+            ZStack {
+                Color(.systemBackground)
+
+                VStack(spacing: 16) {
+                    if let qrImage {
+                        Image(uiImage: qrImage)
+                            .interpolation(.none)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 180, height: 180)
+                            .padding(12)
+                            .background(Color(.systemBackground))
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+
+                    // App branding
+                    HStack(spacing: 6) {
+                        Image("AppIcon")
+                            .resizable()
+                            .frame(width: 16, height: 16)
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                        Text("Sidequest")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .frame(width: cardWidth, height: cardHeight)
+        .clipShape(RoundedRectangle(cornerRadius: 24))
+        .overlay(
+            RoundedRectangle(cornerRadius: 24)
+                .stroke(Color(.systemGray4), lineWidth: 0.5)
+        )
+    }
+}
+
+// MARK: - QR Code Generator
+
+enum QRCodeGenerator {
+    static func generate(from string: String, size: CGFloat = 200) -> UIImage? {
+        let context = CIContext()
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(string.utf8)
+        filter.correctionLevel = "M"
+
+        guard let output = filter.outputImage else { return nil }
+
+        let scale = size / output.extent.size.width
+        let scaled = output.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+
+        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else { return nil }
+        return UIImage(cgImage: cgImage)
+    }
+}
+
+// MARK: - Share Card Screen
+
+struct ProfileShareCardView: View {
+    let user: User
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var renderedImage: UIImage?
+    @State private var showShareSheet = false
+    @State private var profileImage: UIImage?
+
+    private var qrImage: UIImage? {
+        QRCodeGenerator.generate(from: "sidequest://add-friend/\(user.username)")
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color(.systemGroupedBackground)
+                    .ignoresSafeArea()
+
+                VStack(spacing: 32) {
+                    Spacer()
+
+                    // Card preview
+                    ProfileShareCardContent(
+                        user: user,
+                        qrImage: qrImage,
+                        profileImage: profileImage
+                    )
+                    .shadow(color: .black.opacity(0.08), radius: 16, y: 8)
+
+                    // Action buttons
+                    HStack(spacing: 12) {
+                        Button {
+                            renderAndShare()
+                        } label: {
+                            Label("Teilen", systemImage: "square.and.arrow.up")
+                                .font(.subheadline.weight(.semibold))
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 12)
+                                .background(Color(.systemIndigo))
+                                .foregroundStyle(.white)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+
+                        Button {
+                            renderImage()
+                            if let image = renderedImage {
+                                UIPasteboard.general.image = image
+                            }
+                        } label: {
+                            Label("Kopieren", systemImage: "doc.on.doc")
+                                .font(.subheadline.weight(.semibold))
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 12)
+                                .background(Color(.systemGray5))
+                                .foregroundStyle(.primary)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+                    }
+                    .padding(.horizontal, 32)
+
+                    Spacer()
+                }
+            }
+            .navigationTitle("Profil teilen")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Fertig") { dismiss() }
+                }
+            }
+            .sheet(isPresented: $showShareSheet) {
+                if let image = renderedImage {
+                    ShareSheetView(items: [image])
+                }
+            }
+            .task {
+                await loadProfileImage()
+            }
+        }
+    }
+
+    private func loadProfileImage() async {
+        guard let urlString = user.profileImageUrl,
+              let url = URL(string: urlString) else { return }
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            profileImage = UIImage(data: data)
+        } catch {}
+    }
+
+    @MainActor
+    private func renderImage() {
+        let content = ProfileShareCardContent(
+            user: user,
+            qrImage: qrImage,
+            profileImage: profileImage
+        )
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = 3
+        renderedImage = renderer.uiImage
+    }
+
+    @MainActor
+    private func renderAndShare() {
+        renderImage()
+        if renderedImage != nil {
+            showShareSheet = true
+        }
+    }
+}
+
+// MARK: - UIKit Share Sheet wrapper
+
+struct ShareSheetView: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}


### PR DESCRIPTION
## Summary                                                    
  - Neue ProfileShareCardView mit Indigo/White Card-Design (Profilbild, Username, QR-Code)                                                                                               
  - QR-Code enthält Deep Link `sidequest://add-friend/{username}` – beim Scannen wird automatisch eine Freundschaftsanfrage ausgelöst
  - URL-Scheme `sidequest://` in Info.plist registriert, Deep Link Handler mit Bestätigungs-Alert in Sidequest3App                                                                       
  - Share-Button im Profil öffnet jetzt die neue Share Card statt dem einfachen ShareLink                                                                                                
  - Bild wird mit ImageRenderer @3x gerendert und kann über iOS Share Sheet geteilt oder in die Zwischenablage kopiert werden